### PR TITLE
Update repository configuration in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://wpackagist.org/"
+            "url": "https://wpackagist.org/",
+            "only": ["wpackagist-plugin/*"]
         },
         {
             "type": "package",


### PR DESCRIPTION
Specifically, a restriction has been added to limit the 'https://wpackagist.org/' repository to 'wpackagist-plugin/*' packages.